### PR TITLE
Added options for ureport

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,12 @@ Other variables allow to configure libreport:
 - **abrt_mailx_send_duplicate**: Send notification for duplicated events ([true]/false)
 - **abrt_sosreport**: Generate sosreport ([true]/false)
 - **abrt_backtrace**: Control backtrace generation, requires gdb ([false]/full/simple)
+- **abrt_ureport**: Control use of the ureport plugin
+- **abrt_ureport_url**: ureport URL
+- **abrt_ureport_ssl_verify**: Set to true to validate the ureport_url CA
+- **abrt_ureport_contact_email**: If defined, adds an email for followup on generated reports
+- **abrt_ureport_authdata**: Set to true to add ureport AuthData
+- **abrt_ureport_authdata_items**: Items to add to ureport AuthData
+- **abrt_ureport_ssl_clientauth**: If SSL client authentication is used, how do we find it?
+- **abrt_ureport_http_auth**: If HTTP basic authentication is used, what is it?
+

--- a/templates/ureport.conf.erb
+++ b/templates/ureport.conf.erb
@@ -1,0 +1,27 @@
+# File managed by Puppet, modifications will be overidden!
+
+<% if @abrt_ureport -%>
+URL = <%= @abrt_ureport_url %>
+<% if @abrt_ureport_ssl_verify -%>
+SSLVerify = yes
+<% else -%>
+SSLVerify = no
+<% end -%>
+<% if @abrt_ureport_contact_email -%>
+ContactEmail = <%= @abrt_ureport_contact_email %>
+<% end -%>
+<% if @abrt_ureport_authdata -%>
+IncludeAuthData = yes
+<% end -%>
+AuthDataItems = <%= @abrt_ureport_authdata_items.join(', ') %>
+<% if @abrt_ureport_ssl_clientauth -%>
+SSLClientAuth = <%= @abrt_ureport_ssl_clientauth %>
+<% end -%>
+<% if @abrt_ureport_http_auth -%>
+HTTPAuth = <%= @abrt_ureport_http_auth %>
+<% end -%>
+<% else -%>
+
+# abrt_ureport parameter is 'false', nothing to do here
+
+<% end -%>


### PR DESCRIPTION
The foreman ABRT plugin uses ureport to collect messages.  This PR adds bits to manage the ureport settings of abrt.